### PR TITLE
Switch to PEP 420 native namespace.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 Changes
 *******
 
-1.2 (unreleased)
+2.0 (unreleased)
 ================
 
 - Drop support for Python 3.8.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changes
 2.0 (unreleased)
 ================
 
+- Drop support for ``pkg_resources`` namespace and replace it with PEP 420 native namespace. Caution: This change requires to switch all packages in the namespace of the package to versions using a PEP 420 namespace.
+
 - Drop support for Python 3.8.
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 import os
 
-from setuptools import find_packages
 from setuptools import setup
 
 
@@ -41,9 +40,6 @@ setup(
     author_email='grok-dev@zope.org',
     url='https://github.com/zopefoundation/z3c.recipe.mkdir',
     license='ZPL-2.1',
-    packages=find_packages('src'),
-    package_dir={'': 'src'},
-    namespace_packages=['z3c', 'z3c.recipe'],
     include_package_data=True,
     zip_safe=False,
     python_requires='>=3.9',
@@ -54,11 +50,11 @@ setup(
     extras_require={
         'test': [
             'zope.testing',
-            'zope.testrunner',
+            'zope.testrunner >= 6.4',
         ],
         'testing': [
             'zope.testing',
-            'zope.testrunner',
+            'zope.testrunner >= 6.4',
         ],
         'docs': ['Sphinx'],
     },

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages
 from setuptools import setup
 
 
-version = '1.2.dev0'
+version = '2.0.dev0'
 
 with open("README.rst") as f:
     README = f.read()

--- a/src/z3c/__init__.py
+++ b/src/z3c/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)  # pragma: no cover

--- a/src/z3c/recipe/__init__.py
+++ b/src/z3c/recipe/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)  # pragma: no cover


### PR DESCRIPTION
- **Bumped version for breaking release.**
- **Drop support for ``pkg_resources`` namespace and replace it with PEP 420 native namespace. Caution: This change requires to switch all packages in the namespace of the package to versions using a PEP 420 namespace.**
- **Switch to PEP 420 native namespace.**
